### PR TITLE
Fix array use to be more compatible

### DIFF
--- a/examples/simple_menu/simple_menu.sh
+++ b/examples/simple_menu/simple_menu.sh
@@ -177,15 +177,15 @@ while true; do
     # Back to the previous menu
     # '''''''''''''''''''''''''
     if (( ${#MENU_STACK[*]} == 1 )); then
-      process_menu ${MENU_STACK[-1]}
+      process_menu ${MENU_STACK[${#MENU_STACK[*]}-1]} 
     else
       # Unstack the newly found submenu
       # '''''''''''''''''''''''''''''''
-      unset MENU_STACK[-1]
+      unset ${MENU_STACK[${#MENU_STACK[*]}-1]}
 
       # And generate the previous menu
       # ''''''''''''''''''''''''''''''
-      process_menu ${MENU_STACK[-1]}
+      process_menu ${MENU_STACK[${#MENU_STACK[*]}-1]}
     fi
 
   elif [[ $SEL == ">"* ]]; then


### PR DESCRIPTION
Trivial patch.   Referencing array position with -1 is a fairly new adition to bash (4.3+).   Assumes index starts at 0 which is fine for this use.